### PR TITLE
pitch knobs working

### DIFF
--- a/core/MiSynth.cpp
+++ b/core/MiSynth.cpp
@@ -10,10 +10,12 @@ using namespace stk;
 MiOsc::MiOsc() {
     m_waveShape = SAW;
     m_oscVolume = 0.5;
+    m_tune = 1.0;
+    m_freq = 200.0;
 
-    m_sine.setFrequency(200.0);
-    m_blitSaw.setFrequency(200.0);
-    m_blitSquare.setFrequency(200.0);
+    m_sine.setFrequency(m_freq);
+    m_blitSaw.setFrequency(m_freq);
+    m_blitSquare.setFrequency(m_freq);
 }
 
 //-----------------------------------------------------------------------------
@@ -44,9 +46,21 @@ void MiOsc::setVolume(StkFloat volume) {
 // desc: Set frequency for the oscilator
 //-----------------------------------------------------------------------------
 void MiOsc::setFrequency(double freq) {
+    m_freq = freq;
+    freq *= m_tune;
+
     m_sine.setFrequency(freq);
     m_blitSaw.setFrequency(freq);
     m_blitSquare.setFrequency(freq);
+}
+
+//-----------------------------------------------------------------------------
+// name: setTuning()
+// desc: Set tuning of the oscilator
+//-----------------------------------------------------------------------------
+void MiOsc::setTuning(double tune) {
+    m_tune = tune;
+    setFrequency(m_freq);
 }
 
 //-----------------------------------------------------------------------------
@@ -200,6 +214,17 @@ void MiVoice::setWaveShape(int oscNum, int waveShape) {
 void MiVoice::setOscVolume(int oscNum, StkFloat volume) {
     m_oscillators.at(oscNum)->setVolume(volume);
 }
+//-----------------------------------------------------------------------------
+// name: setOscTuning()
+// desc: set the tuning of the oscillator
+//-----------------------------------------------------------------------------
+void MiVoice::setOscTuning(int oscNum, double oscTuning) {
+    m_oscillators.at(oscNum)->setTuning(oscTuning);
+}
+
+  //---------//
+ // MiSynth //
+//---------//
 
 //-----------------------------------------------------------------------------
 // name: MiSynth()
@@ -340,3 +365,12 @@ void MiSynth::setFilterMix(StkFloat filterMix) {
     m_filterMix = filterMix;
 }
 
+//-----------------------------------------------------------------------------
+// name: setOscTuning()
+// desc: set the tuning of the oscillator
+//-----------------------------------------------------------------------------
+void MiSynth::setOscTuning(int oscNum, double oscTuning) {
+    for (int i = 0; i < m_numVoices; i++) {
+        m_voices.at(i)->setOscTuning(oscNum, oscTuning);
+    }
+}

--- a/core/MiSynth.h
+++ b/core/MiSynth.h
@@ -32,13 +32,16 @@ public:
 
 public:
     StkFloat tick();
-    void setWaveShape( int waveShape );
-    void setVolume( StkFloat volume );
-    void setFrequency( double freq );
+    void setWaveShape(int waveShape);
+    void setVolume(StkFloat volume);
+    void setFrequency(double freq);
+    void setTuning(StkFloat oscTuning);
 
 private:
     int m_waveShape;
     StkFloat m_oscVolume;
+    double m_tune;
+    double m_freq;
 
     BlitSaw m_blitSaw;
     BlitSquare m_blitSquare;
@@ -64,6 +67,7 @@ public:
     void setADSR(StkFloat A, StkFloat D, StkFloat S, StkFloat R);
     void setWaveShape(int oscNum, int waveShape);
     void setOscVolume(int oscNum, StkFloat volume);
+    void setOscTuning(int oscNum, double oscTuning);
     int getNote();
 
 private:
@@ -100,6 +104,7 @@ public:
     void setFilter(StkFloat cutFreq, StkFloat resonance);
     void setWaveShape(int oscNum, int waveShape);
     void setOscVolume(int oscNum, StkFloat oscVolume);
+    void setOscTuning(int oscNum, double oscTuning);
     void setFilterMix(StkFloat filterMix);
 
 private:

--- a/micahSynth.cpp
+++ b/micahSynth.cpp
@@ -135,6 +135,7 @@ int main() {
   int intensity = 0;
   int knobNumber = 0;
   int waveShape = 0;
+  double tune = 1.0;
   StkFloat cutoff = 440.0;
   StkFloat resonance = 0.98;
   StkFloat maxResonance = 0.98;
@@ -319,6 +320,16 @@ int main() {
               case 29:  // mod wheel, filter cutoff
                 cutoff = (StkFloat)( 20.0 + intensity * 10000.0 / 128.0 );
                 g_micahSynth->setFilter(cutoff, resonance);
+                break;
+              case 0:
+                break;
+              case 3:
+                tune = 0.5 + 1.5 * (intensity / 127.0);
+                g_micahSynth->setOscTuning(1, tune);
+                break;
+              case 6:
+                tune = 0.5 + 1.5 * (intensity / 127.0);
+                g_micahSynth->setOscTuning(2, tune);
                 break;
               case 1:
                 waveShape = intensity / 32;


### PR DESCRIPTION
Tuning knobs for osc 2 and 3.  osc 1 is held at the midi note. You can modulate the pitch by multiplying by a range of 0.5 to 2, thus an octave up and an octave down.

Consider knob 0 for octave jumping knob